### PR TITLE
Added pitch bend support

### DIFF
--- a/ControllerDocs/iCon QConPro.txt
+++ b/ControllerDocs/iCon QConPro.txt
@@ -1,0 +1,127 @@
+MIDI-OX
+ TIMESTAMP IN PORT STATUS DATA1 DATA2 CHAN NOTE EVENT
+
+=================================================
+Nuendo mode, Cubase mode, Reason Mode, Bitwig
+=================================================
+
+Encoders
+  0001B339   1   5     B0    17    41    1  ---  CC: 23 (E-MU)
+  CW: 1 - 9
+  CCW: 41 - 49
+
+Buttons
+  00035052   1   6     90    0F    7F    1  Eb 0 Note On
+  000350AF   1   5     90    0F    00    1  Eb 0 Note Off
+
+Faders
+  000AAA3E   1   5     E7    40    7D    8  ---  Pitch Bend
+  000AAA3E   1   5     E7    00    7E    8  ---  Pitch Bend
+  000AAA3E   1   5     E7    40    7E    8  ---  Pitch Bend
+  000AAA3E   1   5     E7    00    7F    8  ---  Pitch Bend
+  000AAA3E   1   5     E7    40    7F    8  ---  Pitch Bend
+  000AAA51   1   5     E7    71    7F    8  ---  Pitch Bend   (max value)
+  0008EB5A   1   5     90    6F    7F    1  Eb 8 Note On
+  0008EC30   1   6     90    6F    00    1  Eb 8 Note Off
+
+Jog
+  000D3BE9   1   6     B0    3C    45    1  ---  Control Change
+  000D41C1   1   5     B0    3C    01    1  ---  Control Change
+  CW: 1 - 9
+  CCW: 41 - 49
+
+
+=================================================
+Logic Pro mode, Samplitude mode - seems to have higher fader resolution
+=================================================
+
+Encoders, Buttons and Jog see above
+
+Faders
+  00015A14   1   5     E7    5E    71    8  ---  Pitch Bend
+  00015A91   1   5     E7    18    72    8  ---  Pitch Bend
+  00015A91   1   5     E7    52    72    8  ---  Pitch Bend
+  00015C12   1   5     E7    0C    73    8  ---  Pitch Bend
+  00015D62   1   6     E7    7B    73    8  ---  Pitch Bend  (max value logic pro)
+  00012216   1   6     E7    44    77    8  ---  Pitch Bend  (max value samplitude)
+
+
+=================================================
+Live mode
+=================================================
+
+Encoders and Buttons see above
+
+Faders
+  0000DF60   1   6     E7    7F    7F    8  ---  Pitch Bend (max value Live mode)
+
+Jog (only ONE step CW and CCW)
+  00017205   1   6     B0    3C    08    1  ---  Control Change
+  00017762   1   5     B0    3C    48    1  ---  Control Change
+
+
+=================================================
+Pro Tools
+=================================================
+
+Encoders
+  0000270B   1   6     B0    47    01    1  ---  CC: Harmonic Content
+  00002AB1   1   5     B0    47    41    1  ---  CC: Harmonic Content
+  CW: 1 - 9
+  CCW: 41 - 49
+
+Buttons
+  0002B23C   1   5     B0    0F    07    1  ---  Control Change
+  0002B240   1   6     B0    2F    47    1  ---  Control Change
+  0002B244   1   6     B0    0F    07    1  ---  Control Change
+  0002B248   1   6     B0    2F    07    1  ---  Control Change
+
+Faders 7-bit 0-127
+  00044B72   1   6     B0    07    00    1  ---  CC: Volume     (min value Pro Tools mode)
+  000501C4   1   6     B0    07    7C    1  ---  CC: Volume
+  00050256   1   6     B0    07    7D    1  ---  CC: Volume
+  0005029C   1   6     B0    07    7E    1  ---  CC: Volume
+  000502B0   1   5     B0    07    7F    1  ---  CC: Volume     (max value Pro Tools mode)
+
+Jog
+  0006E4FC   1   6     B0    0D    01    1  ---  Control Change
+  0006F291   1   5     B0    0D    41    1  ---  Control Change
+  CW: 1 - 9
+  CCW: 41 - 49
+
+
+=================================================
+Reaper Mode, Studio one mode
+=================================================
+
+Encoders (only ONE step CW and CCW)
+  00003B13   1   6     B0    17    01    1  ---  CC: 23 (E-MU)
+  00003B94   1   5     B0    17    41    1  ---  CC: 23 (E-MU)
+
+Buttons and Faders see Cubase
+
+Jog (only ONE step CW and CCW)
+  00032D8B   1   6     B0    3C    01    1  ---  Control Change
+  00032E42   1   5     B0    3C    41    1  ---  Control Change
+
+
+=================================================
+MIDI Learn mode - all controllers work in ABSOLUTE MODE
+=================================================
+
+Encoders 7-bit 0-127
+  0000A1F8   1   6     B0    17    00    1  ---  CC: 23 (E-MU)
+  0000A1F8   1   6     B0    17    7F    1  ---  CC: 23 (E-MU)
+
+Buttons
+  00029831   1   6     90    07    7F    1  G -1 Note On
+  0002987F   1   5     90    07    00    1  G -1 Note Off
+
+Faders 7-bit 0-127
+  0001B50A   1   6     E7    00    00    8  ---  Pitch Bend
+  0001B50A   1   6     E7    00    7F    8  ---  Pitch Bend
+
+Jog 7-bit 0-127
+  00038B66   1   6     B0    3C    00    1  ---  Control Change
+  00038B66   1   6     B0    3C    7F    1  ---  Control Change
+

--- a/Source/CommandMap.cpp
+++ b/Source/CommandMap.cpp
@@ -73,11 +73,13 @@ void CommandMap::toXMLDocument(File& file) const {
     for (const auto& map_entry : message_map_) {
       auto* setting = new XmlElement{"setting"};
       setting->setAttribute("channel", map_entry.first.channel);
-      if (map_entry.first.isCC)
-        setting->setAttribute("controller", map_entry.first.controller);
-      else
-        setting->setAttribute("note", map_entry.first.pitch);
-      setting->setAttribute("command_string", map_entry.second);
+	  switch (map_entry.first.messageType)
+	  {
+		  case NOTE: setting->setAttribute("note", map_entry.first.pitch);                break;
+		  case CC: setting->setAttribute("controller", map_entry.first.controller);       break;
+		  case PITCHBEND: setting->setAttribute("pitchbend", map_entry.first.controller); break;
+	  }
+	  setting->setAttribute("command_string", map_entry.second);
       root.addChildElement(setting);
     }
     if (!root.writeToFile(file, ""))

--- a/Source/CommandMap.h
+++ b/Source/CommandMap.h
@@ -26,8 +26,10 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "Pattern/Subject.h"
 
+enum MessageType{NOTE, CC, PITCHBEND};
+
 struct MIDI_Message {
-  bool isCC;
+	MessageType messageType;
   int channel;
   union {
     int controller;
@@ -35,18 +37,18 @@ struct MIDI_Message {
     int data;
   };
 
-  MIDI_Message(): isCC(0),
+  MIDI_Message(): messageType(NOTE),
     channel(0),
     data(0)
 
   {}
 
-  MIDI_Message(int ch, int dat, bool iscc): channel(ch),
-    isCC(iscc),
+  MIDI_Message(int ch, int dat, MessageType msgType): channel(ch),
+    messageType(msgType),
     data(dat) {}
 
   bool operator==(const MIDI_Message &other) const {
-    return (isCC == other.isCC && channel == other.channel && data == other.data);
+    return (messageType == other.messageType && channel == other.channel && data == other.data);
   }
 };
 
@@ -55,7 +57,7 @@ namespace std {
   template <>
   struct hash<MIDI_Message> {
     std::size_t operator()(const MIDI_Message& k) const noexcept {
-      return (std::hash<bool>()(k.isCC) ^ std::hash<int>()(k.channel) ^
+      return (std::hash<int>()(k.messageType) ^ std::hash<int>()(k.channel) ^
         (std::hash<int>()(k.data) << 1));
     }
   };

--- a/Source/CommandTableModel.cpp
+++ b/Source/CommandTableModel.cpp
@@ -166,6 +166,15 @@ void CommandTableModel::buildFromXml(const XmlElement * const root) {
           getStringAttribute("command_string"), note);
       }
     }
+    else if (setting->hasAttribute("pitchbend")) {
+      const MIDI_Message note{
+		  setting->getIntAttribute("channel"),
+          setting->getIntAttribute("pitchbend"),
+		  PITCHBEND};
+
+      addRow(note.channel, note.pitch, PITCHBEND);
+	  command_map_->addCommandforMessage(setting->getStringAttribute("command_string"), note);
+    }
     setting = setting->getNextElement();
   }
 }

--- a/Source/CommandTableModel.cpp
+++ b/Source/CommandTableModel.cpp
@@ -40,17 +40,34 @@ void CommandTableModel::paintRowBackground(Graphics &g, int /*rowNumber*/,
 
 void CommandTableModel::paintCell(Graphics &g, int row_number, int column_id,
   int width, int height, bool /*rowIsSelected*/) {
+
+	int value = 0, channel = 0;
+	String formatStr;
+	
   g.setColour(Colours::black);
   g.setFont(12.0f);
 
   if (column_id == 1) // write the MIDI message in the MIDI command column
   {
-    if (commands_[row_number].isCC)
-      g.drawText(String::formatted("%d | CC: %d", commands_[row_number].channel,
-      commands_[row_number].controller), 0, 0, width, height, Justification::centred);
-    else
-      g.drawText(String::formatted("%d | Note: %d", commands_[row_number].channel,
-      commands_[row_number].pitch), 0, 0, width, height, Justification::centred);
+	  switch (commands_[row_number].messageType)
+	  {
+	  case NOTE:
+		  formatStr = "%d | Note: %d";
+		  channel = commands_[row_number].channel;
+		  value = commands_[row_number].pitch;
+		  break;
+	  case CC:
+		  formatStr = "%d | CC: %d";
+		  channel = commands_[row_number].channel;
+		  value = commands_[row_number].controller;
+		  break;
+	  case PITCHBEND:
+		  formatStr = "%d | Pitch: %d";
+		  channel = commands_[row_number].channel;
+		  value = commands_[row_number].controller;
+		  break;
+	  }
+	  g.drawText(String::formatted(formatStr , channel, value), 0, 0, width, height, Justification::centred);
   }
 }
 
@@ -81,8 +98,8 @@ Component *CommandTableModel::refreshComponentForCell(int row_number,
     return nullptr;
 }
 
-void CommandTableModel::addRow(int midi_channel, int midi_data, bool is_cc) {
-  const MIDI_Message msg{midi_channel, midi_data, is_cc};
+void CommandTableModel::addRow(int midi_channel, int midi_data, MessageType msgType) {
+  const MIDI_Message msg{midi_channel, midi_data, msgType};
   if (command_map_) {
     if (!command_map_->messageExistsInMap(msg)) {
       commands_.push_back(msg);
@@ -121,8 +138,8 @@ void CommandTableModel::buildFromXml(const XmlElement * const root) {
   while ((setting) && (command_map_)) {
     if (setting->hasAttribute("controller")) {
       const MIDI_Message message{setting->getIntAttribute("channel"),
-        setting->getIntAttribute("controller"), true};
-      addRow(message.channel, message.controller, true);
+        setting->getIntAttribute("controller"), CC};
+      addRow(message.channel, message.controller, CC);
 
       // older versions of MIDI2LR stored the index of the string, so we should attempt to parse this as well
       if (setting->getIntAttribute("command", -1) != -1) {
@@ -136,8 +153,8 @@ void CommandTableModel::buildFromXml(const XmlElement * const root) {
     }
     else if (setting->hasAttribute("note")) {
       const MIDI_Message note{setting->getIntAttribute("channel"),
-        setting->getIntAttribute("note"), false};
-      addRow(note.channel, note.pitch, false);
+        setting->getIntAttribute("note"), NOTE};
+      addRow(note.channel, note.pitch, NOTE);
 
       // older versions of MIDI2LR stored the index of the string, so we should attempt to parse this as well
       if (setting->getIntAttribute("command", -1) != -1) {
@@ -153,10 +170,10 @@ void CommandTableModel::buildFromXml(const XmlElement * const root) {
   }
 }
 
-int CommandTableModel::getRowForMessage(int midi_channel, int midi_data, bool is_cc) const {
+int CommandTableModel::getRowForMessage(int midi_channel, int midi_data, MessageType msgType) const {
   for (auto idx = 0; idx < rows_; idx++) {
     if (commands_[idx].channel == midi_channel && commands_[idx].controller == midi_data
-      && commands_[idx].isCC == is_cc)
+      && commands_[idx].messageType == msgType)
       return idx;
   }
   //could not find

--- a/Source/CommandTableModel.h
+++ b/Source/CommandTableModel.h
@@ -43,7 +43,7 @@ public:
     bool isRowSelected, Component *existingComponentToUpdate) override;
 
   // adds a row with a corresponding MIDI message to the table
-  void addRow(int midi_channel, int midi_data, bool isCC);
+  void addRow(int midi_channel, int midi_data, MessageType msgType);
 
   // removes a row from the table
   void removeRow(int row);
@@ -55,7 +55,7 @@ public:
   void buildFromXml(const XmlElement * const elem);
 
   // returns the index of the row associated to a particular MIDI message
-  int getRowForMessage(int midi_channel, int midi_data, bool isCC) const;
+  int getRowForMessage(int midi_channel, int midi_data, MessageType msgType) const;
 
 private:
   int rows_{0};

--- a/Source/LR_IPC_In.cpp
+++ b/Source/LR_IPC_In.cpp
@@ -155,7 +155,12 @@ void LR_IPC_IN::processLine(const juce::String& line) {
           ((msg.controller < 128) ? 127.0 : 16383.0) * original_value));
 
         if (midi_sender_) {
-          midi_sender_->sendCC(msg.channel, msg.controller, value);
+			switch (msg.messageType)
+			{
+				case NOTE: midi_sender_->sendCC(msg.channel, msg.controller, value); break;
+				case CC: midi_sender_->sendCC(msg.channel, msg.controller, value); break;
+				case PITCHBEND: midi_sender_->sendPitchBend(msg.channel, static_cast<int>(round(original_value * 15300.0))); break;
+			}
         }
       }
     }

--- a/Source/LR_IPC_Out.cpp
+++ b/Source/LR_IPC_Out.cpp
@@ -106,6 +106,10 @@ void LR_IPC_OUT::handleMidiNote(int midi_channel, int note) {
   }
 }
 
+void LR_IPC_OUT::handlePitchWheel(int midi_channel, int value) {
+	MIDI_Message message{ midi_channel, value, true };
+}
+
 void LR_IPC_OUT::connectionMade() {
   for (auto listener : listeners_)
     listener->connected();

--- a/Source/LR_IPC_Out.cpp
+++ b/Source/LR_IPC_Out.cpp
@@ -62,7 +62,7 @@ void LR_IPC_OUT::sendCommand(const String &command) {
 }
 
 void LR_IPC_OUT::handleMidiCC(int midi_channel, int controller, int value) {
-  MIDI_Message message{midi_channel, controller, true};
+  MIDI_Message message{midi_channel, controller, CC};
 
   if (command_map_) {
     if (!command_map_->messageExistsInMap(message) ||
@@ -86,7 +86,7 @@ void LR_IPC_OUT::handleMidiCC(int midi_channel, int controller, int value) {
 }
 
 void LR_IPC_OUT::handleMidiNote(int midi_channel, int note) {
-  MIDI_Message message{midi_channel, note, false};
+  MIDI_Message message{midi_channel, note, NOTE};
 
   if (command_map_) {
     if (!command_map_->messageExistsInMap(message) ||
@@ -107,7 +107,27 @@ void LR_IPC_OUT::handleMidiNote(int midi_channel, int note) {
 }
 
 void LR_IPC_OUT::handlePitchWheel(int midi_channel, int value) {
-	MIDI_Message message{ midi_channel, value, true };
+  MIDI_Message message{midi_channel, midi_channel, PITCHBEND};
+
+  if (command_map_) {
+    if (!command_map_->messageExistsInMap(message) ||
+      command_map_->getCommandforMessage(message) == "Unmapped" ||
+      find(LRCommandList::NextPrevProfile.begin(),
+      LRCommandList::NextPrevProfile.end(),
+      command_map_->getCommandforMessage(message)) != LRCommandList::NextPrevProfile.end())
+      return;
+
+    auto command_to_send = command_map_->getCommandforMessage(message);
+    double computed_value = value;
+    computed_value /= 15300.0; // ToDo: make setter for this to push in the setting from the SettingsManager
+    
+    command_to_send += String::formatted(" %g\n", computed_value);
+    {
+      std::lock_guard<decltype(command_mutex_)> lock(command_mutex_);
+      command_ += command_to_send;
+    }
+    triggerAsyncUpdate();
+  }
 }
 
 void LR_IPC_OUT::connectionMade() {

--- a/Source/LR_IPC_Out.h
+++ b/Source/LR_IPC_Out.h
@@ -58,6 +58,7 @@ public:
   // MIDICommandListener interface
   virtual void handleMidiCC(int midiChannel, int controller, int value) override;
   virtual void handleMidiNote(int midiChannel, int note) override;
+  virtual void handlePitchWheel(int midiChannel, int value) override;
 
 private:
   // IPC interface

--- a/Source/MIDIProcessor.cpp
+++ b/Source/MIDIProcessor.cpp
@@ -50,9 +50,16 @@ void MIDIProcessor::handleIncomingMidiMessage(MidiInput * /*device*/,
         listener->handleMidiCC(channel, control, value);
   }
   else if (message.isNoteOn()) {
-    for (auto listener : listeners_) {
-      listener->handleMidiNote(message.getChannel(), message.getNoteNumber());
-    }
+	  for (auto listener : listeners_) {
+		  listener->handleMidiNote(message.getChannel(), message.getNoteNumber());
+	  }
+  }
+  else if (message.isPitchWheel()) {
+    const auto value =
+      static_cast<unsigned short int>(message.getPitchWheelValue());
+	  for (auto listener : listeners_) {
+		  listener->handlePitchWheel(message.getChannel(), value);
+	  }
   }
 }
 

--- a/Source/MIDIProcessor.h
+++ b/Source/MIDIProcessor.h
@@ -30,6 +30,7 @@ class MIDICommandListener {
 public:
   virtual void handleMidiCC(int midi_channel, int controller, int value) = 0;
   virtual void handleMidiNote(int midi_channel, int note) = 0;
+  virtual void handlePitchWheel(int midi_channel, int value) = 0;
 
   virtual ~MIDICommandListener() {};
 };

--- a/Source/MIDISender.cpp
+++ b/Source/MIDISender.cpp
@@ -30,9 +30,9 @@ void MIDISender::Init(void) {
 
 void MIDISender::sendCC(int midi_channel, int controller, int value) const {
   if (controller < 128) { // regular message
-    for (auto dev : output_devices)
-      dev->sendMessageNow(MidiMessage::controllerEvent(midi_channel, controller,
-      value));
+	  for (auto dev : output_devices) {
+		  dev->sendMessageNow(MidiMessage::controllerEvent(midi_channel, controller, value));
+	  }
   }
   else { // NRPN
     const auto parameterLSB = controller & 0x7f;
@@ -46,6 +46,12 @@ void MIDISender::sendCC(int midi_channel, int controller, int value) const {
       dev->sendMessageNow(MidiMessage::controllerEvent(midi_channel, 38, valueLSB));
     }
   }
+}
+
+void MIDISender::sendPitchBend(int midi_channel, int value) const {
+	for (auto dev : output_devices) {
+		dev->sendMessageNow(MidiMessage::pitchWheel(midi_channel, value));
+	}
 }
 
 void MIDISender::rescanDevices() {

--- a/Source/MIDISender.h
+++ b/Source/MIDISender.h
@@ -32,6 +32,8 @@ public:
 
   // sends a CC message to all output devices
   void sendCC(int midi_channel, int controller, int value) const;
+  // sends a PitchBend message to all output devices
+  void sendPitchBend(int midi_channel, int value) const;
 
   // re-enumerates MIDI OUT devices
   void rescanDevices();

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -190,24 +190,24 @@ void MainContentComponent::paint(Graphics& g) {
 void MainContentComponent::handleMidiCC(int midi_channel, int controller, int value) {
     // Display the CC parameters and add/highlight row in table corresponding to the CC
   last_command_ = String::formatted("%d: CC%d [%d]", midi_channel, controller, value);
-  command_table_model_.addRow(midi_channel, controller, true);
-  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, controller, true);
+  command_table_model_.addRow(midi_channel, controller, CC);
+  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, controller, CC);
   triggerAsyncUpdate();
 }
 
 void MainContentComponent::handleMidiNote(int midi_channel, int note) {
     // Display the Note parameters and add/highlight row in table corresponding to the Note
   last_command_ = String::formatted("%d: Note [%d]", midi_channel, note);
-  command_table_model_.addRow(midi_channel, note, false);
-  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, note, false);
+  command_table_model_.addRow(midi_channel, note, NOTE);
+  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, note, NOTE);
   triggerAsyncUpdate();
 }
 
 void MainContentComponent::handlePitchWheel(int midi_channel, int value) {
     // Display the Pitch Wheel parameters and add/highlight row in table corresponding to the value
   last_command_ = String::formatted("%d: Pitch [%d]", midi_channel, value);
-  command_table_model_.addRow(midi_channel, midi_channel, true);
-  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, midi_channel, true);
+  command_table_model_.addRow(midi_channel, midi_channel, PITCHBEND);
+  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, midi_channel, PITCHBEND);
   triggerAsyncUpdate();
 }
 
@@ -314,7 +314,7 @@ void MainContentComponent::buttonClicked(Button* button) {
     auto *component = new SettingsComponent{};
     component->Init(settings_manager_);
     dialog_options.content.setOwned(component);
-    dialog_options.content->setSize(400, 300);
+    //dialog_options.content->setSize(400, 300); Why would you want to do this? Breaks the window if new options are added.
     dialog_options.escapeKeyTriggersCloseButton = true;
     dialog_options.useNativeTitleBar = false;
     settings_dialog_.reset(dialog_options.create());

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -203,6 +203,14 @@ void MainContentComponent::handleMidiNote(int midi_channel, int note) {
   triggerAsyncUpdate();
 }
 
+void MainContentComponent::handlePitchWheel(int midi_channel, int value) {
+    // Display the Pitch Wheel parameters and add/highlight row in table corresponding to the value
+  last_command_ = String::formatted("%d: Pitch [%d]", midi_channel, value);
+  command_table_model_.addRow(midi_channel, midi_channel, true);
+  row_to_select_ = command_table_model_.getRowForMessage(midi_channel, midi_channel, true);
+  triggerAsyncUpdate();
+}
+
 void MainContentComponent::connected() {
   connection_label_.setText("Connected to LR", NotificationType::dontSendNotification);
   connection_label_.setColour(Label::backgroundColourId, Colours::greenyellow);

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -59,6 +59,7 @@ public:
   // MIDICommandListener interface
   virtual void handleMidiCC(int midi_channel, int controller, int value) override;
   virtual void handleMidiNote(int midi_channel, int note) override;
+  virtual void handlePitchWheel(int midi_channel, int value) override;
 
   // LRConnectionListener interface
   virtual void connected() override;

--- a/Source/ProfileManager.cpp
+++ b/Source/ProfileManager.cpp
@@ -104,8 +104,21 @@ void ProfileManager::switchToPreviousProfile() {
   switchToProfile(current_profile_index_);
 }
 
+
+void ProfileManager::mapCommand(MIDI_Message msg) {
+
+    if (command_map_->getCommandforMessage(msg) == "Previous Profile") {
+      switch_state_ = SWITCH_STATE::PREV;
+      triggerAsyncUpdate();
+    }
+    else if (command_map_->getCommandforMessage(msg) == "Next Profile") {
+      switch_state_ = SWITCH_STATE::NEXT;
+      triggerAsyncUpdate();
+    }
+}
+
 void ProfileManager::handleMidiCC(int midi_channel, int controller, int value) {
-  const MIDI_Message cc{midi_channel, controller, true};
+  const MIDI_Message cc{midi_channel, controller, CC};
 
   if (command_map_) {
       // return if the value isn't 0 or 127, or the command isn't a valid
@@ -113,38 +126,33 @@ void ProfileManager::handleMidiCC(int midi_channel, int controller, int value) {
     if ((value != 127) || !command_map_->messageExistsInMap(cc))
       return;
 
-    if (command_map_->getCommandforMessage(cc) == "Previous Profile") {
-      switch_state_ = SWITCH_STATE::PREV;
-      triggerAsyncUpdate();
-    }
-    else if (command_map_->getCommandforMessage(cc) == "Next Profile") {
-      switch_state_ = SWITCH_STATE::NEXT;
-      triggerAsyncUpdate();
-    }
+	mapCommand(cc);
   }
 }
 
 void ProfileManager::handleMidiNote(int midi_channel, int note) {
-  const MIDI_Message note_msg{midi_channel, note, false};
+  const MIDI_Message note_msg{midi_channel, note, NOTE};
 
   if (command_map_) {
       // return if the command isn't a valid profile-related command
     if (!command_map_->messageExistsInMap(note_msg))
       return;
 
-    if (command_map_->getCommandforMessage(note_msg) == "Previous Profile") {
-      switch_state_ = SWITCH_STATE::PREV;
-      triggerAsyncUpdate();
-    }
-    else if (command_map_->getCommandforMessage(note_msg) == "Next Profile") {
-      switch_state_ = SWITCH_STATE::NEXT;
-      triggerAsyncUpdate();
-    }
+	mapCommand(note_msg);
   }
 }
 
 void ProfileManager::handlePitchWheel(int midi_channel, int value) {
+  const MIDI_Message pb{midi_channel, midi_channel, PITCHBEND};
 
+  if (command_map_) {
+      // return if the value isn't 0 or 127, or the command isn't a valid
+      // profile-related command
+    if ((value != 127) || !command_map_->messageExistsInMap(pb))
+      return;
+
+	mapCommand(pb);
+  }
 }
 
 void ProfileManager::connected() {

--- a/Source/ProfileManager.cpp
+++ b/Source/ProfileManager.cpp
@@ -143,6 +143,10 @@ void ProfileManager::handleMidiNote(int midi_channel, int note) {
   }
 }
 
+void ProfileManager::handlePitchWheel(int midi_channel, int value) {
+
+}
+
 void ProfileManager::connected() {
   const auto command = String{"ChangedToDirectory "} +
     File::addTrailingSeparator(profile_location_.getFullPathName()) +

--- a/Source/ProfileManager.h
+++ b/Source/ProfileManager.h
@@ -67,6 +67,7 @@ public:
   // MIDICommandListener interface
   virtual void handleMidiCC(int midi_channel, int controller, int value) override;
   virtual void handleMidiNote(int midi_channel, int note) override;
+  virtual void handlePitchWheel(int midi_channel, int value) override;
 
   // LRConnectionListener interface
   virtual void connected() override;

--- a/Source/ProfileManager.h
+++ b/Source/ProfileManager.h
@@ -74,6 +74,7 @@ public:
   virtual void disconnected() override;
 
 private:
+	void mapCommand(MIDI_Message msg);
   // AsyncUpdate interface
   virtual void handleAsyncUpdate() override;
   enum class SWITCH_STATE {

--- a/Source/SettingsComponent.cpp
+++ b/Source/SettingsComponent.cpp
@@ -24,7 +24,7 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 
 constexpr auto SettingsLeft = 20;
 constexpr auto SettingsWidth = 400;
-constexpr auto SettingsHeight = 300;
+constexpr auto SettingsHeight = 470;
 
 SettingsComponent::SettingsComponent(): ResizableLayout{this} {}
 
@@ -99,6 +99,48 @@ void SettingsComponent::Init(std::shared_ptr<SettingsManager>& settings_manager)
     //add this as the lister for the data
     autohide_setting_.addListener(this);
     addAndMakeVisible(autohide_setting_);
+
+    ////// ----------------------- controller section ------------------------------------
+    controllers_group_.setText("Controller Settings");
+    controllers_group_.setBounds(0, 300, SettingsWidth, 160);
+    addToLayout(&controllers_group_, anchorMidLeft, anchorMidRight);
+    addAndMakeVisible(controllers_group_);
+
+    continuous_label_.setFont(Font{12.f, Font::bold});
+    continuous_label_.setText("Enable this, if your DAW controller uses continuous encoders. If disabled (default) encoders are expected to send absolute values between 0 and 127.", NotificationType::dontSendNotification);
+    continuous_label_.setBounds(SettingsLeft, 315, SettingsWidth - 2 * SettingsLeft, 50);
+    addToLayout(&continuous_label_, anchorMidLeft, anchorMidRight);
+    continuous_label_.setEditable(false);
+    continuous_label_.setColour(Label::textColourId, Colours::darkgrey);
+    addAndMakeVisible(continuous_label_);
+
+    continuous_enabled_.addListener(this);
+    continuous_enabled_.setToggleState(ptr->getContinuousEncoders(), NotificationType::dontSendNotification);
+    continuous_enabled_.setBounds(SettingsLeft, 360, SettingsWidth - 2 * SettingsLeft, 32);
+    addToLayout(&continuous_enabled_, anchorMidLeft, anchorMidRight);
+    addAndMakeVisible(continuous_enabled_);
+
+    maxpitch_label_.setFont(Font{12.f, Font::bold});
+    maxpitch_label_.setText("Use this setting to enter the maximum value your pitch bend control is sending.", NotificationType::dontSendNotification);
+    maxpitch_label_.setBounds(SettingsLeft, 380, SettingsWidth - 2 * SettingsLeft, 50);
+    addToLayout(&maxpitch_label_, anchorMidLeft, anchorMidRight);
+    maxpitch_label_.setEditable(false);
+    maxpitch_label_.setColour(Label::textColourId, Colours::darkgrey);
+    addAndMakeVisible(maxpitch_label_);
+
+    pitch_max_value_.addListener(this);
+    pitch_max_value_.setBounds(SettingsLeft, 420, 100, 25);
+	pitch_max_value_.setColour(TextEditor::outlineColourId, Colours::darkgrey);
+	pitch_max_value_.setText(ptr->getPitchMaxValue(), NotificationType::dontSendNotification);
+    addToLayout(&pitch_max_value_, anchorMidLeft, anchorMidRight);
+    addAndMakeVisible(pitch_max_value_);
+
+	// because I cannot get the TextEditor events to do anything I just add an apply button :-)
+	apply_button_.addListener(this);
+    apply_button_.setBounds(SettingsLeft + 120, 420, 100, 25);
+    addToLayout(&apply_button_, anchorMidLeft, anchorMidRight);
+    addAndMakeVisible(apply_button_);
+
     // turn it on
     activateLayout();
   }
@@ -112,6 +154,16 @@ void SettingsComponent::buttonClicked(Button* button) {
   if (button == &pickup_enabled_) {
     if (auto ptr = settings_manager_.lock()) {
       ptr->setPickupEnabled(pickup_enabled_.getToggleState());
+    }
+  }
+  if (button == &continuous_enabled_) {
+    if (auto ptr = settings_manager_.lock()) {
+      ptr->setContinuousEncoders(continuous_enabled_.getToggleState());
+    }
+  }
+  if (button == &apply_button_) {
+    if (auto ptr = settings_manager_.lock()) {
+      ptr->setPitchMaxValue(pitch_max_value_.getText());
     }
   }
   else if (button == &profile_location_button_) {
@@ -150,3 +202,11 @@ void SettingsComponent::sliderValueChanged(Slider* slider) {
     }
   }
 }
+
+void SettingsComponent::textEditorTextChanged(TextEditor &editor) {
+    // ToDo: this event handler is never been called
+	// I don't have a clue about how this JUCE stuff is supposed to work at all.
+	if (true) {
+	}
+}
+

--- a/Source/SettingsComponent.cpp
+++ b/Source/SettingsComponent.cpp
@@ -206,7 +206,13 @@ void SettingsComponent::sliderValueChanged(Slider* slider) {
 void SettingsComponent::textEditorTextChanged(TextEditor &editor) {
     // ToDo: this event handler is never been called
 	// I don't have a clue about how this JUCE stuff is supposed to work at all.
-	if (true) {
+
+    // NULL pointer check
+	if (&editor) {
+		// ToDo: input validation!
+		if (auto ptr = settings_manager_.lock()) {
+		  ptr->setPitchMaxValue(pitch_max_value_.getText());
+		}
 	}
 }
 

--- a/Source/SettingsComponent.h
+++ b/Source/SettingsComponent.h
@@ -27,7 +27,7 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 #include "SettingsManager.h"
 
 class SettingsComponent final: public Component,
-  private ButtonListener, private ResizableLayout, private Slider::Listener {
+	private ButtonListener, private ResizableLayout, private Slider::Listener, private TextEditor::Listener {
 public:
   SettingsComponent();
   ~SettingsComponent();
@@ -36,17 +36,24 @@ private:
   void paint(Graphics&) override;
   virtual void buttonClicked(Button* button) override;
   virtual void sliderValueChanged(Slider* slider) override;
+  virtual void textEditorTextChanged(TextEditor &editor) override;
 
   GroupComponent autohide_group_{};
   GroupComponent pickup_group_{};
   GroupComponent profile_group_{};
+  GroupComponent controllers_group_{};
   Label autohide_explain_label_{};
   Label pickup_label_{"PickupLabel", ""};
   Label profile_location_label_{"Profile Label"};
+  Label continuous_label_{"ContinuousLabel", ""};
+  Label maxpitch_label_{"MaxPitchLabel", ""};
   Slider autohide_setting_;
   std::weak_ptr<SettingsManager> settings_manager_;
   TextButton profile_location_button_{"Choose Profile Folder"};
+  TextButton apply_button_{"Apply"};
   ToggleButton pickup_enabled_{"Enable Pickup Mode"};
+  ToggleButton continuous_enabled_{"Continuous Encoder Mode"};
+  TextEditor pitch_max_value_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SettingsComponent)
 };

--- a/Source/SettingsManager.cpp
+++ b/Source/SettingsManager.cpp
@@ -68,6 +68,7 @@ void SettingsManager::setPickupEnabled(bool enabled) {
     lr_ipc_out_->sendCommand(command);
   }
 }
+
 String SettingsManager::getProfileDirectory() const noexcept {
   return properties_file_->getValue("profile_directory");
 }
@@ -80,6 +81,24 @@ void SettingsManager::setProfileDirectory(const String& profile_directory_name) 
     File profileDir{profile_directory_name};
     profile_manager_->setProfileDirectory(profileDir);
   }
+}
+
+bool SettingsManager::getContinuousEncoders() const noexcept {
+  return properties_file_->getBoolValue("continuous_encoders_enabled", false);
+}
+
+void SettingsManager::setContinuousEncoders(bool enabled) {
+  properties_file_->setValue("continuous_encoders_enabled", enabled);
+  properties_file_->saveIfNeeded();
+}
+
+String SettingsManager::getPitchMaxValue() const noexcept {
+  return properties_file_->getValue("pitch_max_value", "16383.0");
+}
+
+void SettingsManager::setPitchMaxValue(const String& pitch_max_value) {
+  properties_file_->setValue("pitch_max_value", pitch_max_value);
+  properties_file_->saveIfNeeded();
 }
 
 void SettingsManager::connected() {

--- a/Source/SettingsManager.h
+++ b/Source/SettingsManager.h
@@ -36,8 +36,14 @@ public:
   bool getPickupEnabled() const noexcept;
   void setPickupEnabled(bool enabled);
 
+  bool getContinuousEncoders() const noexcept;
+  void setContinuousEncoders(bool enabled);
+
   String getProfileDirectory() const noexcept;
   void setProfileDirectory(const String& profile_directory);
+
+  String getPitchMaxValue() const noexcept;
+  void setPitchMaxValue(const String& pitch_max_value);
 
   // LRConnectionListener interface
   virtual void connected() override;


### PR DESCRIPTION
The iCon QCon Pro console requires to control the faders with pitch bend messages. You can change what the faders send in a cumbersome way, but the always **listen** for pitch bend messages. So there is no motorized faders support.

In this fork I **added support for pitch bend messages**. For this I had to refactor all methods dealing with the isCC parameter. They now expect the new MessageType parameter. I.e. all methods involved in message handling can now handle more than just two messages types.

The values are passed to Lightroom like they were simple control changes, so only the MIDI2LR app has been changed.

OPEN issues as far as I am concerned:
- the QCon console can be set to different control modes, e.g. Cubase mode, Samplitude mode and so on. These modes change the values the controllers are sending quite dramatically. There is one mode that only sends 0-127 for the faders, others have way better resolution. They differ in their MAX VALUE, too! To be on the safe side, I added a now settings parameter so fine-tune the max value according to the console. Right now the setting will be ignored, because the Samplitude max value (15300) is hard coded. I could not manage to get the settings manager to all relevant source locations.
- I also added a setting for a to-be-developed „continuous encoder mode“, because setting the encoders to „absolute 0-127 mode“ using the QCon device is very tedious, too.
- **no testing with other compatible hardware has been made** - I only own the QCon console. The code **should** still work with all other DAW controllers, but someone should double-check this :-)
