### PR TITLE
Toggle check for latest version at startup

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -321,7 +321,7 @@ void MainContentComponent::buttonClicked(juce::Button* button) { //-V2009 overri
     auto* const component = new SettingsComponent{};
     component->Init(settings_manager_);
     dialog_options.content.setOwned(component);
-    dialog_options.content->setSize(400, 300);
+    dialog_options.content->setSize(400, 400);
     dialog_options.escapeKeyTriggersCloseButton = true;
     dialog_options.useNativeTitleBar = false;
     settings_dialog_.reset(dialog_options.create());

--- a/Source/SettingsComponent.cpp
+++ b/Source/SettingsComponent.cpp
@@ -26,7 +26,7 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 namespace {
   constexpr auto kSettingsLeft = 20;
   constexpr auto kSettingsWidth = 400;
-  constexpr auto kSettingsHeight = 300;
+  constexpr auto kSettingsHeight = 400;
 }
 
 SettingsComponent::SettingsComponent(): ResizableLayout{this} {}
@@ -102,6 +102,27 @@ void SettingsComponent::Init(std::weak_ptr<SettingsManager>&& settings_manager) 
     //add this as the lister for the data
     autohide_setting_.addListener(this);
     addAndMakeVisible(autohide_setting_);
+
+	// ---------------------------- version check section -----------------------------------
+	version_group_.setText("Version");
+	version_group_.setBounds(0, 300, kSettingsWidth, 100);
+	addToLayout(&version_group_, anchorMidLeft, anchorMidRight);
+	addAndMakeVisible(version_group_);
+
+	version_label_.setFont(juce::Font{ 12.f, juce::Font::bold });
+	version_label_.setText("Automatic check for new version at startup. You can disable this if you need to stick to a specific older version for some reason. This will prevent the popup saying a new version is available from appearing.", NotificationType::dontSendNotification);
+	version_label_.setBounds(kSettingsLeft, 315, kSettingsWidth - 2 * kSettingsLeft, 50);
+	addToLayout(&version_label_, anchorMidLeft, anchorMidRight);
+	version_label_.setEditable(false);
+	version_label_.setColour(juce::Label::textColourId, juce::Colours::darkgrey);
+	addAndMakeVisible(version_label_);
+
+	version_enabled_.addListener(this);
+	version_enabled_.setToggleState(ptr->getVersionEnabled(), juce::NotificationType::dontSendNotification);
+	version_enabled_.setBounds(kSettingsLeft, 360, kSettingsWidth - 2 * kSettingsLeft, 32); //-V112
+	addToLayout(&version_enabled_, anchorMidLeft, anchorMidRight);
+	addAndMakeVisible(version_enabled_);
+
     // turn it on
     activateLayout();
   }
@@ -115,6 +136,10 @@ void SettingsComponent::buttonClicked(juce::Button* button) { //-V2009 overridde
   if (button == &pickup_enabled_) {
     if (const auto ptr = settings_manager_.lock())
       ptr->setPickupEnabled(pickup_enabled_.getToggleState());
+  }
+  else if (button == &version_enabled_) {
+	  if (const auto ptr = settings_manager_.lock())
+		  ptr->setVersionEnabled(version_enabled_.getToggleState());
   }
   else if (button == &profile_location_button_) {
     juce::FileBrowserComponent browser{

--- a/Source/SettingsComponent.h
+++ b/Source/SettingsComponent.h
@@ -43,14 +43,17 @@ private:
 
   juce::GroupComponent autohide_group_{};
   juce::GroupComponent pickup_group_{};
+  juce::GroupComponent version_group_{};
   juce::GroupComponent profile_group_{};
   juce::Label autohide_explain_label_{};
   juce::Label pickup_label_{"PickupLabel", ""};
+  juce::Label version_label_{ "VersionLabel", "" };
   juce::Label profile_location_label_{"Profile Label"};
   juce::Slider autohide_setting_;
   std::weak_ptr<SettingsManager> settings_manager_;
   juce::TextButton profile_location_button_{"Choose Profile Folder"};
   juce::ToggleButton pickup_enabled_{"Enable Pickup Mode"};
+  juce::ToggleButton version_enabled_{ "Check for new version at startup" };
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SettingsComponent)
 };

--- a/Source/SettingsManager.cpp
+++ b/Source/SettingsManager.cpp
@@ -66,6 +66,16 @@ void SettingsManager::setPickupEnabled(bool enabled) {
     ptr->sendCommand("Pickup " + std::to_string(static_cast<unsigned>(enabled)) + '\n');
   }
 }
+
+bool SettingsManager::getVersionEnabled() const noexcept {
+	return properties_file_->getBoolValue("version_check_enabled", true);
+}
+
+void SettingsManager::setVersionEnabled(bool enabled) {
+	properties_file_->setValue("version_check_enabled", enabled);
+	properties_file_->saveIfNeeded();
+}
+
 juce::String SettingsManager::getProfileDirectory() const noexcept {
   return properties_file_->getValue("profile_directory");
 }

--- a/Source/SettingsManager.h
+++ b/Source/SettingsManager.h
@@ -37,6 +37,9 @@ public:
   bool getPickupEnabled() const noexcept;
   void setPickupEnabled(bool enabled);
 
+  bool getVersionEnabled() const noexcept;
+  void setVersionEnabled(bool enabled);
+
   juce::String getProfileDirectory() const noexcept;
   void setProfileDirectory(const juce::String& profile_directory);
 

--- a/Source/VersionChecker.cpp
+++ b/Source/VersionChecker.cpp
@@ -32,18 +32,20 @@ void VersionChecker::Init(std::weak_ptr<SettingsManager>&& settings_manager) noe
 }
 
 void VersionChecker::run() {
-  const juce::URL version_url{"http://rsjaffe.github.io/MIDI2LR/version.xml"};
-  const std::unique_ptr<juce::XmlElement> version_xml_element{version_url.readEntireXmlStream()};
-
-  if (version_xml_element != nullptr) {
-    int last_checked = 0;
-    if (const auto smp = settings_manager_.lock())
-      last_checked = smp->getLastVersionFound();
-    new_version_ = version_xml_element->getIntAttribute("latest");
-    if (new_version_ > ProjectInfo::versionNumber && new_version_ != last_checked) {
-      if (const auto smp = settings_manager_.lock())
-        smp->setLastVersionFound(new_version_);
-      triggerAsyncUpdate();
+	bool check = true; // check for new version by default
+	if (const auto smp = settings_manager_.lock()) {
+	  check = smp->getVersionEnabled();
+	}
+  if (check) {
+    const juce::URL version_url{ "http://rsjaffe.github.io/MIDI2LR/version.xml" };
+    const std::unique_ptr<juce::XmlElement> version_xml_element{ version_url.readEntireXmlStream() };
+    if (version_xml_element != nullptr) {
+      new_version_ = version_xml_element->getIntAttribute("latest");
+      if (new_version_ > ProjectInfo::versionNumber) {
+        if (const auto smp = settings_manager_.lock())
+          smp->setLastVersionFound(new_version_);
+        triggerAsyncUpdate();
+      }
     }
   }
 }


### PR DESCRIPTION
This is a first PR that enabled me to dive a little into the project.

I wanted at a time to stick with an older version, but the popup at startup was annoying me. So this adds a toggle to deactivate version check at startup.
