### PR TITLE
Do not LrTasks.yield() in shutdown plugin

### DIFF
--- a/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
@@ -16,9 +16,11 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 MIDI2LR.  If not, see <http://www.gnu.org/licenses/>. 
 ------------------------------------------------------------------------------]]
-local LrTasks             = import 'LrTasks'
 
-MIDI2LR.SERVER:send('TerminateApplication 1\n')
-MIDI2LR.RUNNING = false
-MIDI2LR.SERVER:close()
-MIDI2LR.CLIENT:close()
+-- check if MIDI2LR is set because if plugin fails to load in LR, reloading mechanism will fail because MIDI2LR will be unset
+if MIDI2LR and MIDI2LR.RUNNING then
+  MIDI2LR.RUNNING = false
+  MIDI2LR.SERVER:send('TerminateApplication 1\n')
+  MIDI2LR.SERVER:close()
+  MIDI2LR.CLIENT:close()
+end

--- a/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
@@ -19,7 +19,6 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 local LrTasks             = import 'LrTasks'
 
 MIDI2LR.SERVER:send('TerminateApplication 1\n')
-LrTasks.yield()
 MIDI2LR.RUNNING = false
 MIDI2LR.SERVER:close()
 MIDI2LR.CLIENT:close()

--- a/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/ShutDownPlugin.lua
@@ -20,7 +20,11 @@ MIDI2LR.  If not, see <http://www.gnu.org/licenses/>.
 -- check if MIDI2LR is set because if plugin fails to load in LR, reloading mechanism will fail because MIDI2LR will be unset
 if MIDI2LR and MIDI2LR.RUNNING then
   MIDI2LR.RUNNING = false
-  MIDI2LR.SERVER:send('TerminateApplication 1\n')
-  MIDI2LR.SERVER:close()
-  MIDI2LR.CLIENT:close()
+  if MIDI2LR.SERVER then
+    MIDI2LR.SERVER:send('TerminateApplication 1\n')
+    MIDI2LR.SERVER:close()
+  end
+  if MIDI2LR.CLIENT then
+    MIDI2LR.CLIENT:close()
+  end
 end


### PR DESCRIPTION
Fixed bug when reloading plugin from LR:

```
Plug-in error log for plug-in at: /Users/matc/workspace/oss/midi2lr/MIDI2LR/Source/LRPlugin/MIDI2LR.lrplugin

**** Error 1

An error occurred while attempting to run one of the plug-in’s scripts.
AgEventLoop.yieldToScheduler called when yielding is not allowed

**** Error 2

An error occurred while attempting to shut down the plugin.
AgEventLoop.yieldToScheduler called when yielding is not allowed
```