### PR TITLE
Moving MIDIValueToLRValue and LRValueToMIDIValue to ClientUtilities

### DIFF
--- a/Source/LRCommands.cpp
+++ b/Source/LRCommands.cpp
@@ -133,8 +133,8 @@ const std::vector<std::string> LRCommandList::Develop = {
     "Primary Display Before/After Left/Right",
     "Primary Display Before/After Top/Bottom",
     "Primary Display Before",
-    "Show Reference View Horizontal",
-    "Show Reference View Vertical",
+    "Primary Display Reference View — Left/Right",
+    "Primary Display Reference View — Top/Bottom",
     "Primary Display Loupe",
 };
 

--- a/Source/LRPlugin/MIDI2LR.lrplugin/ClientUtilities.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/ClientUtilities.lua
@@ -231,6 +231,21 @@ local function FullRefresh()
   end
 end
 
+local function MIDIValueToLRValue(param, midi_value)
+  -- map midi range to develop parameter range
+  -- expects midi_value 0.0-1.0, doesn't protect against out-of-range
+  local min,max = Limits.GetMinMax(param)
+  return midi_value * (max-min) + min
+end
+
+local function LRValueToMIDIValue(param)
+  -- map develop parameter range to midi range
+  local min,max = Limits.GetMinMax(param)
+  local retval = (LrDevelopController.getValue(param)-min)/(max-min)
+  if retval > 1 then return 1 end
+  if retval < 0 then return 0 end
+  return retval
+end
 
 return {
   CopySettings = CopySettings,
@@ -246,5 +261,7 @@ return {
   FullRefresh = FullRefresh,
   PasteSelectedSettings = PasteSelectedSettings,
   PasteSettings = PasteSettings,
-  ApplySettings = ApplySettings
+  ApplySettings = ApplySettings,
+  MIDIValueToLRValue = MIDIValueToLRValue,
+  LRValueToMIDIValue = LRValueToMIDIValue
 }

--- a/Source/LRPlugin/MIDI2LR.lrplugin/MenuList.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/MenuList.lua
@@ -591,13 +591,13 @@
   },
   {
     "ShoVwRefHoriz",
-    "Show Reference View Horizontal",
+    "Primary Display Reference View — Left/Right",
     "Develop",
     true
   },
   {
     "ShoVwRefVert",
-    "Show Reference View Vertical",
+    "Primary Display Reference View — Top/Bottom",
     "Develop",
     true
   },


### PR DESCRIPTION
Required by #278 and #379 