### PR TITLE
Lr popups (bezel change) show wrong values not matching LR integer ones

### DIFF
--- a/Source/LRPlugin/MIDI2LR.lrplugin/Client.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/Client.lua
@@ -424,7 +424,7 @@ LrTasks.startAsyncTask(
           LastParam = param
           if ProgramPreferences.ClientShowBezelOnChange then
             local bezelname = ParamList.ParamDisplay[param] or param
-            LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value,Ut.precision(value)))
+            LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value))
           end
           if ParamList.ProfileMap[param] then
             Profiles.changeProfile(ParamList.ProfileMap[param])
@@ -433,9 +433,8 @@ LrTasks.startAsyncTask(
           if ProgramPreferences.ClientShowBezelOnChange then -- failed pickup. do I display bezel?
             value = CU.MIDIValueToLRValue(param, midi_value)
             local actualvalue = LrDevelopController.getValue(param)
-            local precision = Ut.precision(value)
             local bezelname = ParamList.ParamDisplay[param] or param
-            LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value,precision)..'  '..LrStringUtils.numberToStringWithSeparators(actualvalue,precision))
+            LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value)..'  '..LrStringUtils.numberToStringWithSeparators(actualvalue))
           end
           if lastfullrefresh + 1 < os.clock() then --try refreshing controller once a second
             CU.FullRefresh()
@@ -457,7 +456,7 @@ LrTasks.startAsyncTask(
       LastParam = param
       if ProgramPreferences.ClientShowBezelOnChange then
         local bezelname = ParamList.ParamDisplay[param] or param
-        LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value,Ut.precision(value)))
+        LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(value))
       end
       if ParamList.ProfileMap[param] then
         Profiles.changeProfile(ParamList.ProfileMap[param])
@@ -526,7 +525,7 @@ LrTasks.startAsyncTask(
                   if ProgramPreferences.ClientShowBezelOnChange then
                     local bezelname = ParamList.ParamDisplay[resetparam] or resetparam
                     local lrvalue = LrDevelopController.getValue(resetparam)
-                    LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(lrvalue,Ut.precision(lrvalue)))
+                    LrDialogs.showBezel(bezelname..'  '..LrStringUtils.numberToStringWithSeparators(lrvalue))
                   end
                 end
               elseif(SETTINGS[param]) then -- do something requiring the transmitted value to be known

--- a/Source/LRPlugin/MIDI2LR.lrplugin/Utilities.lua
+++ b/Source/LRPlugin/MIDI2LR.lrplugin/Utilities.lua
@@ -220,20 +220,6 @@ local function execFIM(F,Rnil,...)
   return Rnil
 end
 
---------------------------------------------------------------------------------
--- Calculates number of digits to display to right of decimal point.
--- Tries to maintain 4 digits of precision
--- @tparam number value The value that will be displayed
--- @treturn number Number of digits to display to right of decimal point
---------------------------------------------------------------------------------
-local function precision(value)
-  if value == 0 then
-    return 0 
-  else
-    return math.max(0,3-math.floor(math.log10(math.abs(value))))
-  end
-end
-
 --- @export
 return { --table of exports, setting table member name and module function it points to
   wrapFOM = wrapFOM,
@@ -242,5 +228,4 @@ return { --table of exports, setting table member name and module function it po
   execFOM = execFOM,
   execFCM = execFCM,
   execFIM = execFIM,
-  precision = precision,
 }


### PR DESCRIPTION
I was wondering if it is intentional to use the decimal numbers or not ? Because the values didplayed in the LR popups were not matching the values LR use (which are integers and not decimals)